### PR TITLE
libcdatetime_extern.h: fix incorrect macro usage

### DIFF
--- a/libcdatetime/libcdatetime_extern.h
+++ b/libcdatetime/libcdatetime_extern.h
@@ -24,8 +24,12 @@
 
 #include <common.h>
 
-#if defined( __has_attribute ) && __has_attribute( visibility ) && !defined( __CYGWIN__ ) && !defined( _WIN32 )
+#if defined( __has_attribute ) && !defined( __CYGWIN__ ) && !defined( _WIN32 )
+#if __has_attribute( visibility )
 #define LIBCDATETIME_INTERNAL	__attribute__((visibility("hidden"))) extern
+#else
+#define LIBCDATETIME_INTERNAL	extern
+#endif
 #else
 #define LIBCDATETIME_INTERNAL	extern
 #endif


### PR DESCRIPTION
Same fix: https://github.com/libyal/libuna/pull/16